### PR TITLE
Outputs number culture-invariant

### DIFF
--- a/ExtrusionMultiplierService.cs
+++ b/ExtrusionMultiplierService.cs
@@ -110,8 +110,8 @@ namespace Calibrator
                         var eString = regex.Match(line).Value.Substring(1);
                         double originalValue = double.Parse(eString, CultureInfo.InvariantCulture);
                         double adjustedValue = originalValue * multiplier;
-                        var newLine = regex.Replace(line, $"E{adjustedValue.ToString("0.00000")}");
-                        newLine = $"{newLine} ;Flow adjsuted from {originalValue} to {adjustedValue.ToString("0.00000")} with multiplier {multiplier.ToString("0.00000")}";
+                        var newLine = regex.Replace(line, $"E{adjustedValue.ToString("0.00000", CultureInfo.InvariantCulture)}");
+                        newLine = $"{newLine} ;Flow adjusted from {originalValue} to {adjustedValue.ToString("0.00000", CultureInfo.InvariantCulture)} with multiplier {multiplier.ToString("0.00000", CultureInfo.InvariantCulture)}";
                         this.logger.Verbose(newLine);
                         newLines.Add(newLine);
                     }


### PR DESCRIPTION
Fixes an issue where the numbers were exported with `,` instead of `.`